### PR TITLE
Fixing missing imports

### DIFF
--- a/django_contact_importer/contacts/views.py
+++ b/django_contact_importer/contacts/views.py
@@ -3,9 +3,9 @@
 from django.shortcuts import redirect, render_to_response
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from contact_importer.providers import (GoogleContactImporter, 
-                                        YahooContactImporter, 
-                                        LiveContactImporter)
+from contact_importer.providers.google import GoogleContactImporter
+from contact_importer.providers.yahoo import YahooContactImporter 
+from contact_importer.providers.live import LiveContactImporter
 
 providers = {
     "google": GoogleContactImporter,


### PR DESCRIPTION
At last version of contact_importer there is a problem about importing, it is necessary to repoint to correct library